### PR TITLE
FAI-2418 Vacancy Analytics not adding started

### DIFF
--- a/src/SFA.DAS.BusinessMetrics.Application/GetVacancyMetrics/Queries/GetVacancyMetricsQueryHandler.cs
+++ b/src/SFA.DAS.BusinessMetrics.Application/GetVacancyMetrics/Queries/GetVacancyMetricsQueryHandler.cs
@@ -2,6 +2,7 @@
 using SFA.DAS.BusinessMetrics.Application.Mediatr.Responses;
 using SFA.DAS.BusinessMetrics.Domain.Constants;
 using SFA.DAS.BusinessMetrics.Domain.Interfaces.Services;
+using SFA.DAS.BusinessMetrics.Domain.Models;
 
 namespace SFA.DAS.BusinessMetrics.Application.GetVacancyMetrics.Queries
 {
@@ -10,42 +11,30 @@ namespace SFA.DAS.BusinessMetrics.Application.GetVacancyMetrics.Queries
         public async Task<ValidatedResponse<GetVacancyMetricsQueryResult>> Handle(GetVacancyMetricsQuery request, CancellationToken cancellationToken)
         {
             var metricsResult = await MetricServices.GetVacancyMetrics(request.StartDate, request.EndDate, cancellationToken);
-            
+
             var vacancyMetrics = metricsResult.GroupBy(x => x.VacancyReference)
                 .Select(metrics => new GetVacancyMetricsQueryResult.VacancyMetric
                 {
                     VacancyReference = metrics.Key,
-                    ViewsCount =
-                        metrics.Any(fil => fil.Name!.Contains($"{MetricConstants.Vacancy.Views}",
-                            StringComparison.InvariantCultureIgnoreCase))
-                            ? metrics.Where(fil => fil.Name!.Contains($"{MetricConstants.Vacancy.Views}",
-                                StringComparison.InvariantCultureIgnoreCase)).Select(x => x.Count).FirstOrDefault()
-                            : 0,
-                    ApplicationStartedCount =
-                        metrics.Any(fil => fil.Name!.Contains($"{MetricConstants.Vacancy.Started}",
-                            StringComparison.InvariantCultureIgnoreCase))
-                            ? metrics.Where(fil => fil.Name!.Contains($"{MetricConstants.Vacancy.Started}",
-                                StringComparison.InvariantCultureIgnoreCase)).Select(x => x.Count).FirstOrDefault()
-                            : 0,
-                    ApplicationSubmittedCount =
-                        metrics.Any(fil => fil.Name!.Contains($"{MetricConstants.Vacancy.Submitted}",
-                            StringComparison.InvariantCultureIgnoreCase))
-                            ? metrics.Where(fil => fil.Name!.Contains($"{MetricConstants.Vacancy.Submitted}",
-                                StringComparison.InvariantCultureIgnoreCase)).Select(x => x.Count).FirstOrDefault()
-                            : 0,
-                    SearchResultsCount =
-                        metrics.Any(fil => fil.Name!.Contains($"{MetricConstants.Vacancy.SearchResults}",
-                            StringComparison.InvariantCultureIgnoreCase))
-                            ? metrics.Where(fil => fil.Name!.Contains($"{MetricConstants.Vacancy.SearchResults}",
-                                StringComparison.InvariantCultureIgnoreCase)).Select(x => x.Count).FirstOrDefault()
-                            : 0,
+                    ViewsCount = GetMetricCount(metrics, MetricConstants.Vacancy.Views),
+                    ApplicationStartedCount = GetMetricCount(metrics, MetricConstants.Vacancy.Started),
+                    ApplicationSubmittedCount = GetMetricCount(metrics, MetricConstants.Vacancy.Submitted),
+                    SearchResultsCount = GetMetricCount(metrics, MetricConstants.Vacancy.SearchResults)
                 })
                 .ToList();
 
             return new ValidatedResponse<GetVacancyMetricsQueryResult>(new GetVacancyMetricsQueryResult
             {
-               VacancyMetrics = vacancyMetrics.ToList()
+                VacancyMetrics = [.. vacancyMetrics]
             });
+        }
+
+        private static long GetMetricCount(IEnumerable<VacancyMetrics> metrics, string metricName)
+        {
+            return metrics
+                .Where(fil => fil.Name!.Contains(metricName, StringComparison.InvariantCultureIgnoreCase))
+                .Select(x => x.Count)
+                .FirstOrDefault();
         }
     }
 }

--- a/src/SFA.DAS.BusinessMetrics.Domain.UnitTests/ServicesTests/VacancyMetricServicesTests.cs
+++ b/src/SFA.DAS.BusinessMetrics.Domain.UnitTests/ServicesTests/VacancyMetricServicesTests.cs
@@ -3,7 +3,6 @@ using Azure.Core;
 using Azure.Monitor.Query;
 using Azure.Monitor.Query.Models;
 using FluentAssertions;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using SFA.DAS.BusinessMetrics.Domain.Configuration;
@@ -23,9 +22,7 @@ namespace SFA.DAS.BusinessMetrics.Domain.UnitTests.ServicesTests
             DateTime endDate,
             List<VacancyMetrics> vacancyMetrics,
             LogAnalyticsWorkSpace logAnalyticsWorkSpace,
-            MetricsConfiguration metricsConfiguration,
             [Frozen] Mock<ILogsQueryClient> mockLogsQueryClient,
-            [Frozen] Mock<ILogger<VacancyMetricServices>> mockLogger,
             [Frozen] Mock<IOptions<LogAnalyticsWorkSpace>> mockLogAnalyticsWorkspace,
             [Frozen] Mock<IOptions<MetricsConfiguration>> mockMetricsConfigurationOptions)
         {
@@ -40,13 +37,12 @@ namespace SFA.DAS.BusinessMetrics.Domain.UnitTests.ServicesTests
             var logsTable = MonitorQueryModelFactory.LogsTable("tester", logsTableColumns.AsEnumerable(), logsTableRows.AsEnumerable());
 
             mockLogAnalyticsWorkspace.Setup(ap => ap.Value).Returns(logAnalyticsWorkSpace);
-            mockMetricsConfigurationOptions.Setup(ap => ap.Value).Returns(metricsConfiguration);
 
             mockLogsQueryClient.Setup(x => x.ProcessQuery(It.IsAny<ResourceIdentifier>(), It.IsAny<string>(),
                     It.IsAny<QueryTimeRange>(), CancellationToken.None))
                 .ReturnsAsync(logsTable);
 
-            var sut = new VacancyMetricServices(mockMetricsConfigurationOptions.Object, mockLogAnalyticsWorkspace.Object, mockLogsQueryClient.Object);
+            var sut = new VacancyMetricServices(mockLogAnalyticsWorkspace.Object, mockLogsQueryClient.Object);
 
             var actual = await sut.GetVacancyMetrics(startDate, endDate, CancellationToken.None);
 

--- a/src/SFA.DAS.BusinessMetrics.Domain/Services/AzureMonitorLogsQueryClient.cs
+++ b/src/SFA.DAS.BusinessMetrics.Domain/Services/AzureMonitorLogsQueryClient.cs
@@ -30,7 +30,7 @@ namespace SFA.DAS.BusinessMetrics.Domain.Services
                 {
                     Retry = { NetworkTimeout = _networkTimeout, MaxRetries = MaxRetries, Delay = _delay }
                 }),
-                new VisualStudioCodeCredential(options: new VisualStudioCodeCredentialOptions()
+                new VisualStudioCodeCredential(options: new VisualStudioCodeCredentialOptions
                 {
                     Retry = { NetworkTimeout = _networkTimeout, MaxRetries = MaxRetries, Delay = _delay }
                 })));

--- a/src/SFA.DAS.BusinessMetrics.Domain/Services/HealthCheckServices.cs
+++ b/src/SFA.DAS.BusinessMetrics.Domain/Services/HealthCheckServices.cs
@@ -22,11 +22,14 @@ namespace SFA.DAS.BusinessMetrics.Domain.Services
 
         public async Task<HealthCheckResult> GetHealthCheck(CancellationToken token)
         {
+            var query = @"
+                Heartbeat
+                | summarize count() by Computer
+                | project Computer";
+
             var result = await _queryClient.ProcessQuery(
                 new ResourceIdentifier(_logAnalyticsWorkSpaceConfiguration.Identifier),
-                $"Heartbeat " +
-                $"| summarize count() by Computer " +
-                $"| project Computer",
+                query,
                 new QueryTimeRange(DateTimeOffset.UtcNow.AddMinutes(-30), DateTimeOffset.UtcNow),
                 token);
 

--- a/src/SFA.DAS.BusinessMetrics.Domain/Services/MetricServices.cs
+++ b/src/SFA.DAS.BusinessMetrics.Domain/Services/MetricServices.cs
@@ -8,9 +8,6 @@ namespace SFA.DAS.BusinessMetrics.Domain.Services
     {
         private readonly MetricsConfiguration _metricsConfiguration = metricsConfigurationOptions.Value;
 
-        public List<string> GetMetricServiceNames()
-        {
-            return _metricsConfiguration.CustomMetrics.Select(fil => fil.ServiceName).Distinct().ToList();
-        }
+        public List<string> GetMetricServiceNames() => [.. _metricsConfiguration.CustomMetrics.Select(fil => fil.ServiceName).Distinct()];
     }
 }

--- a/src/SFA.DAS.BusinessMetrics.Domain/Services/VacancyMetricServices.cs
+++ b/src/SFA.DAS.BusinessMetrics.Domain/Services/VacancyMetricServices.cs
@@ -8,12 +8,10 @@ using SFA.DAS.BusinessMetrics.Domain.Models;
 namespace SFA.DAS.BusinessMetrics.Domain.Services
 {
     public class VacancyMetricServices(
-        IOptions<MetricsConfiguration> metricsConfigurationOptions,
         IOptions<LogAnalyticsWorkSpace> logWorkspaceConfigurationOptions,
         ILogsQueryClient queryClient)
         : IVacancyMetricServices
     {
-        private readonly MetricsConfiguration _metricConfiguration = metricsConfigurationOptions.Value;
         private readonly LogAnalyticsWorkSpace _logAnalyticsWorkSpaceConfiguration = logWorkspaceConfigurationOptions.Value;
 
         public async Task<List<VacancyMetrics>> GetVacancyMetrics(
@@ -21,24 +19,26 @@ namespace SFA.DAS.BusinessMetrics.Domain.Services
             DateTime endDate,
             CancellationToken token)
         {
+            var query = $"{Constants.MetricConstants.CustomMetricsTableName} " +
+                       $"| where Name contains '{Constants.MetricConstants.CustomDimensions.VacancyDimensionName}' " +
+                       $"| extend CustomDimension = tostring(Properties.['{Constants.MetricConstants.CustomDimensions.VacancyReference}']) " +
+                       $"| summarize Count = count() by CustomDimension, Name " +
+                       $"| order by CustomDimension ";
+
             var result = await queryClient.ProcessQuery(
                 new ResourceIdentifier(_logAnalyticsWorkSpaceConfiguration.Identifier),
-                $"{Constants.MetricConstants.CustomMetricsTableName} " +
-                $"| where Name contains '{Constants.MetricConstants.CustomDimensions.VacancyDimensionName}'" +
-                $"| extend CustomDimension = tostring(Properties.['{Constants.MetricConstants.CustomDimensions.VacancyReference}'])" +
-                $"| summarize Count = count() by CustomDimension, Name" +
-                $"| order by CustomDimension",
+                query,
                 new QueryTimeRange(startDate, endDate),
-                token);
+                token);            
 
             return result is not { Rows.Count: > 0 }
                 ? []
-                : result.Rows.Select(row => new VacancyMetrics
+                : [.. result.Rows.Select(row => new VacancyMetrics
                 {
                     VacancyReference = Convert.ToString(row[0]),
                     Name = Convert.ToString(row[1]),
                     Count = Convert.ToInt64(row[2]),
-                }).ToList();
+                })];
         }
     }
 }


### PR DESCRIPTION
✨ Refactor vacancy metrics handling and tests

- Introduced `GetMetricCount` method to reduce code duplication.
- Simplified test setup in `VacancyMetricServicesTests`.
- Minor formatting updates in `AzureMonitorLogsQueryClient`.
- Enhanced health check query in `HealthCheckServices`.
- Refactored query construction in `GetVacancyMetrics`.

Changes made by Balaji Jambulingam